### PR TITLE
Improve error logging of predict call

### DIFF
--- a/fastsam/model.py
+++ b/fastsam/model.py
@@ -9,6 +9,8 @@ Usage - Predict:
     results = model.predict('ultralytics/assets/bus.jpg')
 """
 
+import traceback
+
 from ultralytics.yolo.cfg import get_cfg
 from ultralytics.yolo.engine.exporter import Exporter
 from ultralytics.yolo.engine.model import YOLO
@@ -50,6 +52,7 @@ class FastSAM(YOLO):
         try:
             return self.predictor(source, stream=stream)
         except Exception as e:
+            LOGGER.error(traceback.format_exc())
             return None
 
     def train(self, **kwargs):


### PR DESCRIPTION
Right now because the exception is caught and just return None it is impossible to debug what is wrong with the model. Adding error logging.